### PR TITLE
[bugfix] clicking mousedown outside of input area gets you in a bad state

### DIFF
--- a/src/chipper/keyboard.cljs
+++ b/src/chipper/keyboard.cljs
@@ -345,7 +345,8 @@
        [_ literal-chan _ :as id-data] (.split id "-")
        [line chan attr :as parsed-id] (map js/parseInt id-data)]
     ; NB: If the user clicks out of the main area, 'id-data will be '"",
-    ; so we need to check for that explicitly.
+    ; which gets parsed to 'NaN by 'js/parseInt, so we must check for
+    ; that case explicitly.
     ;; This indicates the user clicked in the main area.
     (when (and (== 3 (count parsed-id)) (every? number? parsed-id))
       (swap! state assoc

--- a/src/chipper/keyboard.cljs
+++ b/src/chipper/keyboard.cljs
@@ -344,7 +344,10 @@
   (let [id (.-id (.-target ev))
        [_ literal-chan _ :as id-data] (.split id "-")
        [line chan attr :as parsed-id] (map js/parseInt id-data)]
-    (when (every? number? parsed-id)  ;; This indicates the user clicked in the main area.
+    ; NB: If the user clicks out of the main area, 'id-data will be '"",
+    ; so we need to check for that explicitly.
+    ;; This indicates the user clicked in the main area.
+    (when (and (== 3 (count parsed-id)) (every? number? parsed-id))
       (swap! state assoc
              :active-line line
              :active-chan chan


### PR DESCRIPTION
postmortem: 

root cause:

turns out that `(== (map js/parseInt "") '(NaN))`, which is fun.

impact:

when you clicked off the main input area, we would do `(swap! state (assoc :active-frame NaN :active-chan nil :active-attr nil))`, thus rendering further keypresses meaningless until you got back to a good `:state` by clicking back on the input area.

next steps:

* validate updates to state?
* write tests?
* make sure to perform validation when taking user input i.e. from the js runtime?

