### PR TITLE
use int-semitone representation for notes instead of names

### DIFF
--- a/src/chipper/keyboard.cljs
+++ b/src/chipper/keyboard.cljs
@@ -1,6 +1,7 @@
 (ns chipper.keyboard
   (:require [chipper.chips :as c]
             [chipper.utils :as u]
+            [chipper.state :as s]
             [chipper.utils :refer [bounded-add]]
             [goog.events :as events]))
 
@@ -223,10 +224,10 @@
   (case internal-key
     :play-pause (c/play-track state (:player @state))
     ;; TODO refactor all the position resets
-    :forward-frame (do (u/check-set-frame-use state)
+    :forward-frame (do (s/check-set-frame-use state)
                        (swap! state assoc
                               :active-frame (min 31 (inc (:active-frame @state)))))
-    :back-frame (do (u/check-set-frame-use state)
+    :back-frame (do (s/check-set-frame-use state)
                     (swap! state assoc
                            :active-frame (max 0 (dec (:active-frame @state))))))
   nil)  ; returning nil skips directives
@@ -356,4 +357,4 @@
     (when (= "f" literal-chan)  ;; This indicates the user clicked on a page.
       (swap! state assoc
              :active-frame line)
-      (u/set-frame-used?! (:active-frame @state) state))))
+      (s/set-frame-used?! (:active-frame @state) state))))

--- a/src/chipper/keyboard.cljs
+++ b/src/chipper/keyboard.cljs
@@ -43,13 +43,13 @@
     common-mappings
     {:edit-attr
      (merge
-       {:KeyA :C   :ShiftKeyA :C# :KeyW :C#
-        :KeyS :D   :ShiftKeyS :D# :KeyE :D#
-        :KeyD :E
-        :KeyF :F   :ShiftKeyF :F# :KeyT :F#
-        :KeyG :G   :ShiftKeyG :G# :KeyY :G#
-        :KeyH :A   :ShiftKeyH :A# :KeyU :A#
-        :KeyJ :B
+       {:KeyA 0   :ShiftKeyA 1 :KeyW 1
+        :KeyS 2   :ShiftKeyS 3 :KeyE 3
+        :KeyD 4
+        :KeyF 5   :ShiftKeyF 6 :KeyT 6
+        :KeyG 7   :ShiftKeyG 8 :KeyY 8
+        :KeyH 9   :ShiftKeyH 10 :KeyU 10
+        :KeyJ 11
         :KeyX :off
         :ShiftKeyX :stop
         :Backspace :delete-above}

--- a/src/chipper/notes.cljs
+++ b/src/chipper/notes.cljs
@@ -1,31 +1,39 @@
 (ns chipper.notes)
 
+; note - number of semitones above C
+; octave - octave number
 (defrecord Note [note octave gain effect])
 
-;; half-steps above C
-;; TODO might as well just shove em in a vector because I don't intend
-;; to add any facility for enharmonics in the editor
-(def note-steps
-  {:C  0
-   :C# 1
-   :D  2
-   :D# 3
-   :E  4
-   :F  5
-   :F# 6
-   :G  7
-   :G# 8
-   :A  9
-   :A# 10
-   :B  11})
+;; Display notes.
+(def -name-rel-c
+  {0 :C
+   1 :C#
+   2 :D
+   3 :D#
+   4 :E
+   5 :F
+   6 :F#
+   7 :G
+   8 :G#
+   9 :A
+   10 :A#
+   11 :B})
+
+(def -semitone-rel-c (zipmap (vals -name-rel-c) (keys -name-rel-c)))
+
+(defn name-rel
+  [root-name semitone]
+  (let [root-semitone (root-name -semitone-rel-c)
+        adjusted-semitone (mod (+ root-semitone semitone) 11)]
+    (get -name-rel-c adjusted-semitone)))
+
 
 ;; realistically don't need this much precision
 (def twelfth-root-of-2 1.059)
 ;; (def twelfth-root-of-2 (js/Math.pow 2 (/ 1 12)))
 
 (defn frequency-
-  {:pre [(note-steps note)]
-   :doc
+  {:doc
    "Calculate the frequency of a note given the note name, octave number,
    and frequency of A4.
 
@@ -33,7 +41,7 @@
    - frequency (Hz)
 
    Params:
-   - note - name of note; # for sharp, b for flat
+   - note - semitones relative to C
    - octave - octave number (default 4)
    - base - base frequency of A4 (default 440)
 
@@ -42,7 +50,7 @@
   [note octave]
   (let [freq-of-a4    440
         steps-from-c4 (+ (* (- octave 4) 12)
-                         (note-steps note)
+                         note
                          -9)] ;; base freq given for A4 but steps calc'd from C4
     (* freq-of-a4
        (js/Math.pow twelfth-root-of-2 steps-from-c4))))

--- a/src/chipper/state.cljs
+++ b/src/chipper/state.cljs
@@ -1,6 +1,5 @@
 (ns chipper.state
-  (:require [clojure.string :refer [split-lines]]
-            [chipper.notes :as notes]))  ; not good to require this in utils
+  (:require [clojure.string :refer [split-lines]]))
 
 (defn reset-cursor! [state]
   "Set the cursor position to top left."
@@ -29,7 +28,7 @@
                              (nil? note) "-"
                              (= :off note) "o"
                              (= :stop note) "s"
-                             :else (.toString (note notes/note-steps) 16))
+                             :else (.toString note 16))
                  octavestr (or octave "-")
                  gainstr   (or gain "-")]
              (str notestr octavestr gainstr)))))
@@ -44,13 +43,11 @@
   one frame per line
   each slice is a sequence of four notes
   each note is a sequence of 3 characters
-   - note is 0-B (0-11) inclusive; o for :off, s for :stop
+   - note is 0-11 inclusive; o for :off, s for :stop
    - octave is 0-9 inclusiv
    - gain is 0-9 inclusive"
   [frames]
   (apply str (interpose "\n" (map serialize-frame frames))))
-
-(def note-reverse-map (zipmap (vals notes/note-steps) (keys notes/note-steps)))
 
 (defn deserialize-slice [serialized-slice]
   (vec
@@ -59,7 +56,7 @@
                       (= "-" note-) nil
                       (= "o" note-) :off
                       (= "s" note-) :stop
-                      :else (note-reverse-map (js/parseInt note- 16)))
+                      :else (js/parseInt note- 16))
             octave  (cond
                       (= "-" octave-) nil
                       :else (js/parseInt octave-))

--- a/src/chipper/ui.cljs
+++ b/src/chipper/ui.cljs
@@ -1,9 +1,14 @@
 (ns chipper.ui
   (:require [chipper.chips :as c]
             [chipper.state :as s]
+            [chipper.notes :as n]
             [goog.string :as gs]
             [goog.string.format]
             [reagent.core :as r]))
+
+
+;; TODO FIXME: everything is relative to :C right now.
+(defn note-name [semitone] (name (n/name-rel :C semitone)))
 
 (defn scheme-line [scheme]
   [:pre#scheme
@@ -43,7 +48,7 @@
                       :off "X"
                       :stop "S"
                       nil  "-"
-                      (name note--))
+                      (note-name note--))
         octave      (or octave "-")
         attr-strs   [(str " " note (when (= 1 (count note)) "-") octave " ")
                      (if gain   (str " " gain " ")   " - ")


### PR DESCRIPTION
lots easier than I thought it was gonna be!

checked:

- [x] saving and loading goldberg works properly, from disk and localstorage
- [x] transposition for the names works properly, try changing the `:C` in `ui/note-name`
- [x] transposition for the names works under implicit-octave numbering, i.e. semitone not bounded in [0,11]